### PR TITLE
Fix showSelf user comparison

### DIFF
--- a/src/WhoReacted/components/Reactors.jsx
+++ b/src/WhoReacted/components/Reactors.jsx
@@ -9,7 +9,7 @@ const VoiceUserSummaryItem = WebpackModules.find(m => m?.default?.displayName ==
 
 function Reactors({ users, currentUser, showSelf, showBots, max, size, count }) {
     const filteredUsers = useMemo(() => {
-        return users.filter(user => (showSelf || user !== currentUser) && (showBots || !user.bot));
+        return users.filter(user => (showSelf || user.id !== currentUser.id) && (showBots || !user.bot));
     }, [users, currentUser, showSelf, showBots]);
 
     function renderMoreUsers(text, className) {


### PR DESCRIPTION
In my case, the `verified` property was true for `currentUser` but not
for `user`, resulting in the user comparison to never match.