### PR TITLE
fix(GuildProfile/lang): correct typo on russian language

### DIFF
--- a/src/GuildProfile/locales/ru.json
+++ b/src/GuildProfile/locales/ru.json
@@ -5,7 +5,7 @@
     "GUILD_PROFILE_BLOCKED_USERS_IN_GUILD": "Заблокированные пользователи",
     "GUILD_PROFILE_LOADING": "Загрузка",
     "GUILD_PROFILE_CLICK_TO_COPY_SERVER_ICON_URL": "Нажмите, чтобы скопировать URL иконки",
-    "GUILD_PROFILE_CREATED_AT": "Канал создан",
+    "GUILD_PROFILE_CREATED_AT": "Сервер создан",
     "GUILD_PROFILE_JOINED_AT": "Вы присоединились",
     "GUILD_PROFILE_GUILD_PREMIUM_SUBSCRIBER_COUNT": "Количество Бустов сервера",
     "GUILD_PROFILE_GUILD_PREMIUM_TIER": "Уровень Бустов сервера",


### PR DESCRIPTION
error in the label "Канал создан" because the date of creation of the server