### PR TITLE
fix(GuildProfile): modal body overflow

### DIFF
--- a/src/GuildProfile/components/GuildProfileModal/index.jsx
+++ b/src/GuildProfile/components/GuildProfileModal/index.jsx
@@ -71,7 +71,7 @@ export default class GuildProfileModal extends React.PureComponent {
                         </TabBar>
                     </div>
                 </div>
-                <div className={classes.body}>{this.renderSelectedSection()}</div>
+                <div className={`${classes.body} guild-profile-body`}>{this.renderSelectedSection()}</div>
             </ModalRoot>
         );
     }

--- a/src/GuildProfile/style.scss
+++ b/src/GuildProfile/style.scss
@@ -30,4 +30,9 @@
     .guild-roles {
         padding: 10px 12px;
     }
+
+    .guild-profile-body {
+        flex: 1;
+        min-height: 0;
+    }
 }


### PR DESCRIPTION
The body of the tabs oveflows the modal because the body has a fixed height of 240px which the modal can't accomodate. 

Before:
![image](https://user-images.githubusercontent.com/50981692/134837337-e1721f4f-7ba1-4aae-ad83-641e91596629.png)
It can't be scrolled down any further.

After:
![image](https://user-images.githubusercontent.com/50981692/134837359-72bc2002-e24f-44d6-ab1e-3ae1adad50d4.png)
Body fits within the modal and can be scrolled down all the way