### PR TITLE
fix(WhoReacted): crash on new update

### DIFF
--- a/dist/WhoReacted/WhoReacted.plugin.js
+++ b/dist/WhoReacted/WhoReacted.plugin.js
@@ -313,7 +313,7 @@ class WhoReacted extends (external_Plugin_default()) {
                 popout.props.children = props => {
                     const reactionInner = renderReactionInner(props);
 
-                    reactionInner.props.children.props.children.push(
+                    reactionInner.props.children.push(
                         external_BdApi_React_default().createElement(components_Reactors, {
                             message: message,
                             emoji: emoji,

--- a/src/WhoReacted/index.jsx
+++ b/src/WhoReacted/index.jsx
@@ -186,7 +186,7 @@ export default class WhoReacted extends Plugin {
                 popout.props.children = props => {
                     const reactionInner = renderReactionInner(props);
 
-                    reactionInner.props.children.props.children.push(
+                    reactionInner.props.children.push(
                         <Reactors
                             message={message}
                             emoji={emoji}


### PR DESCRIPTION
This should fix #280

Why I remove the extra `props.children`? Because when I `console.log` the `reactionInner.props.children`, it looks like this already.
<details>
<summary>console.log</summary>

![Screenshot 2022-04-13 110942](https://user-images.githubusercontent.com/45804108/163100373-cd0244e1-594c-4f5b-91f2-09b56ea7eed7.jpg)

</details>

and `reactionInner.props.children.props` returns `undefined`. So I remove the extra `props.children`, and it works again without crashes.

![image](https://user-images.githubusercontent.com/45804108/163100578-d246a4bb-6ee1-4072-b96f-3b6e4b5ecc6d.png)
