### PR TITLE
feat: add filter to hide blocked users

### DIFF
--- a/dist/WhoReacted/WhoReacted.plugin.js
+++ b/dist/WhoReacted/WhoReacted.plugin.js
@@ -97,16 +97,21 @@ var external_Plugin_default = /*#__PURE__*/__webpack_require__.n(external_Plugin
  function _nullishCoalesce(lhs, rhsFn) { if (lhs != null) { return lhs; } else { return rhsFn(); } } function _optionalChain(ops) { let lastAccessLHS = undefined; let value = ops[0]; let i = 1; while (i < ops.length) { const op = ops[i]; const fn = ops[i + 1]; i += 2; if ((op === 'optionalAccess' || op === 'optionalCall') && value == null) { return undefined; } if (op === 'access' || op === 'optionalAccess') { lastAccessLHS = value; value = fn(value); } else if (op === 'call' || op === 'optionalCall') { value = fn((...args) => value.call(lastAccessLHS, ...args)); lastAccessLHS = undefined; } } return value; }
 
 
-const { UserStore } = external_BoundedLibrary_namespaceObject.DiscordModules;
+const { UserStore, RelationshipStore } = external_BoundedLibrary_namespaceObject.DiscordModules;
 
 const Flux = external_BoundedLibrary_namespaceObject.WebpackModules.getByProps('Store', 'connectStores');
 const ReactionStore = external_BoundedLibrary_namespaceObject.WebpackModules.getByProps('getReactions', '_changeCallbacks');
 const VoiceUserSummaryItem = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => _optionalChain([m, 'optionalAccess', _ => _.default, 'optionalAccess', _2 => _2.displayName]) === 'VoiceUserSummaryItem').default;
 
-function Reactors({ users, currentUser, showSelf, showBots, max, size, count }) {
+function Reactors({ users, currentUser, showSelf, showBots, showBlocked, max, size, count }) {
     const filteredUsers = (0,external_BdApi_React_namespaceObject.useMemo)(() => {
-        return users.filter(user => (showSelf || user.id !== currentUser.id) && (showBots || !user.bot));
-    }, [users, currentUser, showSelf, showBots]);
+        return users.filter(
+            user =>
+                (showSelf || user.id !== currentUser.id) &&
+                (showBots || !user.bot) &&
+                (showBlocked || !RelationshipStore.isBlocked(user.id))
+        );
+    }, [users, currentUser, showSelf, showBots, showBlocked]);
 
     function renderMoreUsers(text, className) {
         return (
@@ -156,7 +161,8 @@ class WhoReacted extends (external_Plugin_default()) {
             userThreshold: 100,
             useHighestUserCount: true,
             showSelf: true,
-            showBots: true
+            showBots: true,
+            showBlocked: true
         };
     }
 
@@ -290,6 +296,14 @@ class WhoReacted extends (external_Plugin_default()) {
                     this.settings.showBots,
                     value => (this.settings.showBots = value)
                 )
+            )
+            .append(
+                new Switch(
+                    'Show blocked users',
+                    'Shows blocked users within the reactors.',
+                    this.settings.showBlocked,
+                    value => (this.settings.showBlocked = value)
+                )
             );
     }
 
@@ -321,6 +335,7 @@ class WhoReacted extends (external_Plugin_default()) {
                             max: this.settings.maxUsersShown,
                             showSelf: this.settings.showSelf,
                             showBots: this.settings.showBots,
+                            showBlocked: this.settings.showBlocked,
                             size: this.settings.avatarSize,}
                         )
                     );

--- a/dist/WhoReacted/WhoReacted.plugin.js
+++ b/dist/WhoReacted/WhoReacted.plugin.js
@@ -97,21 +97,16 @@ var external_Plugin_default = /*#__PURE__*/__webpack_require__.n(external_Plugin
  function _nullishCoalesce(lhs, rhsFn) { if (lhs != null) { return lhs; } else { return rhsFn(); } } function _optionalChain(ops) { let lastAccessLHS = undefined; let value = ops[0]; let i = 1; while (i < ops.length) { const op = ops[i]; const fn = ops[i + 1]; i += 2; if ((op === 'optionalAccess' || op === 'optionalCall') && value == null) { return undefined; } if (op === 'access' || op === 'optionalAccess') { lastAccessLHS = value; value = fn(value); } else if (op === 'call' || op === 'optionalCall') { value = fn((...args) => value.call(lastAccessLHS, ...args)); lastAccessLHS = undefined; } } return value; }
 
 
-const { UserStore, RelationshipStore } = external_BoundedLibrary_namespaceObject.DiscordModules;
+const { UserStore } = external_BoundedLibrary_namespaceObject.DiscordModules;
 
 const Flux = external_BoundedLibrary_namespaceObject.WebpackModules.getByProps('Store', 'connectStores');
 const ReactionStore = external_BoundedLibrary_namespaceObject.WebpackModules.getByProps('getReactions', '_changeCallbacks');
 const VoiceUserSummaryItem = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => _optionalChain([m, 'optionalAccess', _ => _.default, 'optionalAccess', _2 => _2.displayName]) === 'VoiceUserSummaryItem').default;
 
-function Reactors({ users, currentUser, showSelf, showBots, showBlocked, max, size, count }) {
+function Reactors({ users, currentUser, showSelf, showBots, max, size, count }) {
     const filteredUsers = (0,external_BdApi_React_namespaceObject.useMemo)(() => {
-        return users.filter(
-            user =>
-                (showSelf || user.id !== currentUser.id) &&
-                (showBots || !user.bot) &&
-                (showBlocked || !RelationshipStore.isBlocked(user.id))
-        );
-    }, [users, currentUser, showSelf, showBots, showBlocked]);
+        return users.filter(user => (showSelf || user.id !== currentUser.id) && (showBots || !user.bot));
+    }, [users, currentUser, showSelf, showBots]);
 
     function renderMoreUsers(text, className) {
         return (
@@ -161,8 +156,7 @@ class WhoReacted extends (external_Plugin_default()) {
             userThreshold: 100,
             useHighestUserCount: true,
             showSelf: true,
-            showBots: true,
-            showBlocked: true
+            showBots: true
         };
     }
 
@@ -296,14 +290,6 @@ class WhoReacted extends (external_Plugin_default()) {
                     this.settings.showBots,
                     value => (this.settings.showBots = value)
                 )
-            )
-            .append(
-                new Switch(
-                    'Show blocked users',
-                    'Shows blocked users within the reactors.',
-                    this.settings.showBlocked,
-                    value => (this.settings.showBlocked = value)
-                )
             );
     }
 
@@ -335,7 +321,6 @@ class WhoReacted extends (external_Plugin_default()) {
                             max: this.settings.maxUsersShown,
                             showSelf: this.settings.showSelf,
                             showBots: this.settings.showBots,
-                            showBlocked: this.settings.showBlocked,
                             size: this.settings.avatarSize,}
                         )
                     );

--- a/src/WhoReacted/components/Reactors.jsx
+++ b/src/WhoReacted/components/Reactors.jsx
@@ -1,16 +1,21 @@
 import React, { useMemo } from 'react';
 import { DiscordModules, WebpackModules } from '@zlibrary/api';
 
-const { UserStore } = DiscordModules;
+const { UserStore, RelationshipStore } = DiscordModules;
 
 const Flux = WebpackModules.getByProps('Store', 'connectStores');
 const ReactionStore = WebpackModules.getByProps('getReactions', '_changeCallbacks');
 const VoiceUserSummaryItem = WebpackModules.find(m => m?.default?.displayName === 'VoiceUserSummaryItem').default;
 
-function Reactors({ users, currentUser, showSelf, showBots, max, size, count }) {
+function Reactors({ users, currentUser, showSelf, showBots, showBlocked, max, size, count }) {
     const filteredUsers = useMemo(() => {
-        return users.filter(user => (showSelf || user.id !== currentUser.id) && (showBots || !user.bot));
-    }, [users, currentUser, showSelf, showBots]);
+        return users.filter(
+            user =>
+                (showSelf || user.id !== currentUser.id) &&
+                (showBots || !user.bot) &&
+                (showBlocked || !RelationshipStore.isBlocked(user.id))
+        );
+    }, [users, currentUser, showSelf, showBots, showBlocked]);
 
     function renderMoreUsers(text, className) {
         return (

--- a/src/WhoReacted/index.jsx
+++ b/src/WhoReacted/index.jsx
@@ -29,7 +29,8 @@ export default class WhoReacted extends Plugin {
             userThreshold: 100,
             useHighestUserCount: true,
             showSelf: true,
-            showBots: true
+            showBots: true,
+            showBlocked: true
         };
     }
 
@@ -163,6 +164,14 @@ export default class WhoReacted extends Plugin {
                     this.settings.showBots,
                     value => (this.settings.showBots = value)
                 )
+            )
+            .append(
+                new Switch(
+                    'Show blocked users',
+                    'Shows blocked users within the reactors.',
+                    this.settings.showBlocked,
+                    value => (this.settings.showBlocked = value)
+                )
             );
     }
 
@@ -194,6 +203,7 @@ export default class WhoReacted extends Plugin {
                             max={this.settings.maxUsersShown}
                             showSelf={this.settings.showSelf}
                             showBots={this.settings.showBots}
+                            showBlocked={this.settings.showBlocked}
                             size={this.settings.avatarSize}
                         />
                     );


### PR DESCRIPTION
Adds a new filter option "Show blocked", which is on by default but can be disabled to hide blocked users from the shown profile pictures.