### PR TITLE
[WhoReacted]Update 'Reactions' module to renamed 'MessageReactions'

### DIFF
--- a/dist/WhoReacted/WhoReacted.plugin.js
+++ b/dist/WhoReacted/WhoReacted.plugin.js
@@ -46,7 +46,7 @@ function buildPlugin() {
 /******/ 	"use strict";
 /******/ 	// The require scope
 /******/ 	var __webpack_require__ = {};
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
@@ -59,7 +59,7 @@ function buildPlugin() {
 /******/ 			return getter;
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -71,12 +71,12 @@ function buildPlugin() {
 /******/ 			}
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 
@@ -161,7 +161,7 @@ function Reactors({
 
 
 
-const Reactions = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => m?.default?.displayName === 'Reactions').default;
+const Reactions = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => m?.default?.displayName === 'MessageReactions').default;
 const {
     SettingPanel,
     SettingGroup,

--- a/dist/WhoReacted/WhoReacted.plugin.js
+++ b/dist/WhoReacted/WhoReacted.plugin.js
@@ -46,7 +46,7 @@ function buildPlugin() {
 /******/ 	"use strict";
 /******/ 	// The require scope
 /******/ 	var __webpack_require__ = {};
-/******/
+/******/ 	
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
@@ -59,7 +59,7 @@ function buildPlugin() {
 /******/ 			return getter;
 /******/ 		};
 /******/ 	})();
-/******/
+/******/ 	
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -71,12 +71,12 @@ function buildPlugin() {
 /******/ 			}
 /******/ 		};
 /******/ 	})();
-/******/
+/******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
-/******/
+/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 
@@ -161,7 +161,7 @@ function Reactors({
 
 
 
-const Reactions = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => m?.default?.displayName === 'MessageReactions').default;
+const Reactions = external_BoundedLibrary_namespaceObject.WebpackModules.find(m => m?.default?.displayName === 'Reactions').default;
 const {
     SettingPanel,
     SettingGroup,

--- a/src/WhoReacted/index.jsx
+++ b/src/WhoReacted/index.jsx
@@ -15,7 +15,7 @@ import Plugin from '@zlibrary/plugin';
 import Reactors from './components/Reactors';
 import style from './style.scss';
 
-const Reactions = WebpackModules.find(m => m?.default?.displayName === 'Reactions').default;
+const Reactions = WebpackModules.find(m => m?.default?.displayName === 'MessageReactions').default;
 const { SettingPanel, SettingGroup, Textbox, Slider, Switch } = Settings;
 
 export default class WhoReacted extends Plugin {


### PR DESCRIPTION
This should hopefully address https://github.com/jaimeadf/BetterDiscordPlugins/issues/361
It looks like the 'Reactions' module got renamed to 'MessageReactions'
Simple change to rename the module that is searched for.

Let me know if process wasn't followed or if other changes are needed.